### PR TITLE
Feat/deployment target to v11

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,8 +6,7 @@ import PackageDescription
 let package = Package(
     name: "TinySSDP",
     platforms: [
-           SupportedPlatform.iOS(.v12),
-           SupportedPlatform.macOS(.v10_14)
+           SupportedPlatform.iOS(.v11)
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,9 @@ import PackageDescription
 let package = Package(
     name: "TinySSDP",
     platforms: [
-           SupportedPlatform.iOS(.v11)
+        SupportedPlatform.iOS(.v11),
+        SupportedPlatform.macOS(.v10_14)
+        
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.


### PR DESCRIPTION
Decrease the deployment target to support iOS 11 as BlueSocket currently seems to get "no route to host" error when used within an app targeting iOS 12 at minimum